### PR TITLE
Add friends support

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -14,7 +14,7 @@ import {
   User,
 } from "firebase/auth";
 import { auth, db } from "../services/firebase";
-import { doc, getDoc } from "firebase/firestore";
+import { doc, getDoc, setDoc } from "firebase/firestore";
 
 interface AuthContextProps {
   user: User | null;
@@ -61,8 +61,15 @@ export const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
     return unsub;
   }, []);
 
-  const signup = (email: string, pw: string) =>
-    createUserWithEmailAndPassword(auth, email, pw);
+  const signup = async (email: string, pw: string) => {
+    const cred = await createUserWithEmailAndPassword(auth, email, pw);
+    await setDoc(
+      doc(db, "users", cred.user.uid),
+      { email: cred.user.email },
+      { merge: true },
+    );
+    return cred;
+  };
 
   const login = (email: string, pw: string) =>
     signInWithEmailAndPassword(auth, email, pw);

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -7,9 +7,10 @@ import {
   doc,
   setDoc,
   getDoc,
+  deleteDoc,
 } from "firebase/firestore";
 import { auth, db } from "./firebase";
-import { Friend } from "../types/friendTypes";
+import { Friend, FriendRequest } from "../types/friendTypes";
 
 export const fetchFriendsWithShameLevel = async (): Promise<Friend[]> => {
   const user = auth.currentUser;
@@ -43,11 +44,44 @@ export const addFriendByIdentifier = async (identifier: string) => {
   const targetId = targetDoc.id;
   if (targetId === user.uid) throw new Error("Cannot add yourself");
 
-  const targetData = targetDoc.data();
-  const displayName = targetData.username || targetData.email || "Friend";
+  const friendDoc = await getDoc(doc(db, "users", user.uid, "friends", targetId));
+  if (friendDoc.exists()) return;
 
-  await setDoc(doc(db, "users", user.uid, "friends", targetId), {
-    displayName,
+  const currentSnap = await getDoc(doc(db, "users", user.uid));
+  const currentData = currentSnap.data() || {};
+  const currentName = currentData.username || currentData.email || user.email;
+
+  await setDoc(doc(db, "users", targetId, "friendRequests", user.uid), {
+    fromId: user.uid,
+    fromName: currentName,
+  });
+};
+
+export const fetchFriendRequests = async (): Promise<FriendRequest[]> => {
+  const user = auth.currentUser;
+  if (!user) return [];
+
+  const snapshot = await getDocs(
+    collection(db, "users", user.uid, "friendRequests"),
+  );
+  return snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...(doc.data() as Omit<FriendRequest, "id">),
+  }));
+};
+
+export const acceptFriendRequest = async (requesterId: string) => {
+  const user = auth.currentUser;
+  if (!user) return;
+
+  const requestRef = doc(db, "users", user.uid, "friendRequests", requesterId);
+  const requestSnap = await getDoc(requestRef);
+  if (!requestSnap.exists()) return;
+
+  const { fromName } = requestSnap.data() as { fromName?: string };
+
+  await setDoc(doc(db, "users", user.uid, "friends", requesterId), {
+    displayName: fromName || "Friend",
     shameLevel: 0,
   });
 
@@ -55,8 +89,16 @@ export const addFriendByIdentifier = async (identifier: string) => {
   const currentData = currentSnap.data() || {};
   const currentName = currentData.username || currentData.email || user.email;
 
-  await setDoc(doc(db, "users", targetId, "friends", user.uid), {
+  await setDoc(doc(db, "users", requesterId, "friends", user.uid), {
     displayName: currentName,
     shameLevel: 0,
   });
+
+  await deleteDoc(requestRef);
+};
+
+export const rejectFriendRequest = async (requesterId: string) => {
+  const user = auth.currentUser;
+  if (!user) return;
+  await deleteDoc(doc(db, "users", user.uid, "friendRequests", requesterId));
 };

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -1,5 +1,13 @@
 // In workoutService.ts or create friendService.ts
-import { getDocs, collection } from "firebase/firestore";
+import {
+  getDocs,
+  collection,
+  query,
+  where,
+  doc,
+  setDoc,
+  getDoc,
+} from "firebase/firestore";
 import { auth, db } from "./firebase";
 import { Friend } from "../types/friendTypes";
 
@@ -8,8 +16,47 @@ export const fetchFriendsWithShameLevel = async (): Promise<Friend[]> => {
   if (!user) return [];
 
   const snapshot = await getDocs(collection(db, "users", user.uid, "friends"));
-  return snapshot.docs.map(doc => ({
+  return snapshot.docs.map((doc) => ({
     id: doc.id,
     ...(doc.data() as Omit<Friend, "id">),
   }));
+};
+
+export const addFriendByIdentifier = async (identifier: string) => {
+  const user = auth.currentUser;
+  if (!user) return;
+
+  const usersRef = collection(db, "users");
+  let q = query(usersRef, where("username", "==", identifier.toLowerCase()));
+  let snapshot = await getDocs(q);
+
+  if (snapshot.empty) {
+    q = query(usersRef, where("email", "==", identifier.toLowerCase()));
+    snapshot = await getDocs(q);
+  }
+
+  if (snapshot.empty) {
+    throw new Error("User not found");
+  }
+
+  const targetDoc = snapshot.docs[0];
+  const targetId = targetDoc.id;
+  if (targetId === user.uid) throw new Error("Cannot add yourself");
+
+  const targetData = targetDoc.data();
+  const displayName = targetData.username || targetData.email || "Friend";
+
+  await setDoc(doc(db, "users", user.uid, "friends", targetId), {
+    displayName,
+    shameLevel: 0,
+  });
+
+  const currentSnap = await getDoc(doc(db, "users", user.uid));
+  const currentData = currentSnap.data() || {};
+  const currentName = currentData.username || currentData.email || user.email;
+
+  await setDoc(doc(db, "users", targetId, "friends", user.uid), {
+    displayName: currentName,
+    shameLevel: 0,
+  });
 };

--- a/src/types/friendTypes.ts
+++ b/src/types/friendTypes.ts
@@ -3,3 +3,8 @@ export interface Friend {
   displayName: string;
   shameLevel: number;
 }
+
+export interface FriendRequest {
+  id: string;
+  fromName: string;
+}


### PR DESCRIPTION
## Summary
- store user email on signup
- add ability to query and add friends in Firestore
- show friend list and invite form in profile screen

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a33a0b718832baac6158f82e18f04